### PR TITLE
changes of 13 alias-require-import, 14 Module attributes, 15 Structs

### DIFF
--- a/chapter13
+++ b/chapter13
@@ -1,0 +1,109 @@
+alias, require, and import
+  # To facilitate software reuse, Elixir provides three directives (aliases, require, and import) plus a macro called use
+    # Alias the module so it can be called as Bar instead of Foo.Bar
+      alias Foo.Bar, as: Bar
+
+    # Require the module in order to use its macros
+      require Foo
+
+    # Import functions from Foo so they can be called without the `Foo.` prefix
+      import Foo
+
+    # Invokes the custom code defined in Foo as an extension point
+      use Foo
+
+alias
+
+  # Allows you to configure aliases for any given module name.
+  # a module uses a specialized list implemented in Math.List. The directive alias allows you to refer to the Math.List the same as List within the module definition.
+    defmodule Stats do
+      alias Math.List, as: List
+        # In the remaining module definition List expands to Math.List.
+    end
+  # Los alias se utilizan con frecuencia para definir atajos. De hecho, llamar aliassin una :asopción establece el alias automáticamente en la última parte del nombre del módulo, por ejemplo las dos lineas son equivalentes.
+    alias Math.List
+    alias Math.List, as: List
+  # aliases are lexically scoped, allowing you to set aliases within specific functions.
+    defmodule Math do
+      def plus(a, b) do
+        alias Math.List
+        # ...
+      end
+
+      def minus(a, b) do
+        # ...
+      end
+    end
+
+require
+  # Elixir provides macros that expand at compile time as a metaprogramming mechanism.
+  # Public functions in modules are available globally, but when using macros you must choose to request the module in which they are defined.
+    Integer.is_odd(3)
+    ** (CompileError) iex:1: you must require Integer before invoking the macro Integer.is_odd/1
+        (elixir) src/elixir_dispatch.erl:97: :elixir_dispatch.dispatch_require/6
+    require Integer                                                                          #=> Integer
+    Integer.is_odd(3)                                                                        #=> true
+  # In Elixir, Integer.is_odd is defined as a macro. This means that to invoke Integer.is_odd, require must first be called.
+
+importar
+  # Import is used whenever you want to access functions or macros from other modules without using the full name.
+  # For example, if you want to use the duplicate function of the List module several times, you can import it import it
+    import List, only: [duplicate: 2]                                                         #=> List
+    duplicate(:ok, 3)                                                                         #=> [:ok, :ok, :ok]
+  # Import has a lexical scope. This means that you can import specific macros or functions within function definitions.
+    defmodule Math do
+      def some_function do
+        import List, only: [duplicate: 2]
+        duplicate(:ok, 10)
+      end
+    end
+
+use
+  # The use macro is often used as an extension point. This means that, when using a FooBar module, it allows that module to inject any code into the current module, such as importing itself or other modules, defining new functions, setting a module state, and so on.
+    defmodule AssertionTest do
+      use ExUnit.Case, async: true
+
+      test "always pass" do
+        assert true
+      end
+    end
+  # putting this in more general terms.
+    defmodule Example do
+      use Feature, option: :value
+    end
+  # this module compiles into.
+    defmodule Example do
+      require Feature
+      Feature.__using__(option: :value)
+    end
+
+Understanding Aliases
+  # An alias in Elixir is a capitalized identifier (like String, Keyword, etc) that is converted to an atom during compilation.
+    is_atom(String)                                                                           #=> true
+    to_string(String)                                                                         #=> "Elixir.String"
+    :"Elixir.String" == String                                                                #=> true
+  # Aliases are expanded to atoms because in Erlang VM (and consequently Elixir) modules are always represented by atoms.
+    List.flatten([1, [2], 3])                                                                 #=> [1, 2, 3]
+    :"Elixir.List".flatten([1, [2], 3])                                                       #=> [1, 2, 3]
+  # That is the mechanism used to call Erlang modules.
+    :lists.flatten([1, [2], 3])                                                               #=> [1, 2, 3]
+
+Module nesting
+  # Nesting in elixir works as follows
+    defmodule Foo do
+      defmodule Bar do
+      end
+    end
+      # Two modules Foo and Foo.Bar are defined. The second can be accessed from Baradentro Foos as long as they are in the same lexical area.
+  # In Elixir, it is not necessary to define the Foo module before you can define the Foo.Bar module, as they are effectively independent. The above could also be written as.
+    defmodule Foo.Bar do
+    end
+
+    defmodule Foo do
+      alias Foo.Bar
+      # Can still access it as `Bar`
+    end
+
+Multi alias/import/require/use
+  # It is possible to create an alias, import or require several modules at the same time. This is particularly useful once we start nesting modules, which is very common when creating Elixir applications.
+    alias MyApp.{Foo, Bar, Baz}

--- a/chapter14
+++ b/chapter14
@@ -1,0 +1,107 @@
+Module attributes
+  # Los atributos del módulo en Elixir tienen tres propósitos.
+    # Sirven para anotar el módulo, a menudo con información para ser utilizada por el usuario o la VM .
+    # Funcionan como constantes.
+    # Funcionan como un módulo de almacenamiento temporal que se utilizará durante la compilación.
+  # Elixir brings the concept of module attributes from Erlang.
+    defmodule MyServer do
+      @moduledoc "My server code."
+    end
+  # Elixir has many reserved attributes. Here are some of them.
+    # @moduledoc - provides documentation for the current module.
+    # @doc - Provides documentation for the function or macro that follows the attribute.
+    # @spec - Provides a type specification for the function that follows the attribute.
+    # @ behavior- (note British spelling) used to specify an OTP or user-defined behavior.
+  # Defining the math.ex function
+    elixirc math.ex
+    h Math                                                          #=> Access the docs for the module Math
+    h Math.sum                                                      #=> Access the docs for the sum function
+
+As “constants”
+  # Elixir developers often use module attributes when they want to make a value more visible or reusable.
+    defmodule MyServer do
+      @initial_state %{host: "127.0.0.1", port: 3456}
+      IO.inspect @initial_state
+    end
+  # Trying to access an attribute that was not defined will give a warning.
+    defmodule MyServer do
+      @unknown
+    end
+    warning: undefined module attribute @unknown, please remove access to
+    @unknown or explicitly set it before access
+  # Attributes can also be read within functions.
+    defmodule MyServer do
+      @my_data 14
+      def first_data, do: @my_data
+      @my_data 13
+      def second_data, do: @my_data
+    end
+
+    MyServer.first_data                                                 #=> 14
+    MyServer.second_data                                                #=> 13
+  # Functions can be called by defining a module attribute.
+    defmodule MyApp.Status do
+      @service URI.parse("https://example.com")
+      def status(email) do
+        SomeHttpClient.get(@service)
+      end
+    end
+  # The above function will be called at compile time and its return value, not the call to the function itself, is what will replace the attribute. So the above will effectively compile to this.
+    defmodule MyApp.Status do
+      def status(email) do
+        SomeHttpClient.get(%URI{
+          authority: "example.com",
+          host: "example.com",
+          port: 443,
+          scheme: "https"
+        })
+      end
+    end
+  # Every time an attribute is read within a function, Elixir takes a snapshot of its current value. So if you read the same attribute multiple times within multiple functions, you may end up making multiple copies of it. Usually that's not a problem, but if you're using functions to calculate attributes of large modules, that can slow down compilation. The solution is to move the attribute to the shared function.
+    # you can use this, but it is not convenient
+      def some_function, do: do_something_with(@example)
+      def another_function, do: do_something_else_with(@example)
+    # It is better to use this.
+      def some_function, do: do_something_with(example())
+      def another_function, do: do_something_else_with(example())
+      defp example, do: @example
+
+Accumulating attributes
+  # repeating a module attribute will cause its value to be reassigned, but there are circumstances where it is possible to configure the module attribute so that its values are accumulated.
+    defmodule Foo do
+      Module.register_attribute __MODULE__, :param, accumulate: true
+
+      @param :foo
+      @param :bar
+      # here @param == [:bar, :foo]
+    end
+
+As temporary storage
+  # ExUnit uses module attributes for multiple different purposes.
+    defmodule MyTest do
+      use ExUnit.Case, async: true
+
+      @tag :external
+      @tag os: :unix
+      test "contacts external service" do
+        # ...
+      end
+    end
+  # You can define a structure that combines both fields with explicit default values and implicit nil values. The fields that are implicitly defaulted must first be specified as null.
+    defmodule User do
+      defstruct [:email, name: "John", age: 27]
+    end
+    %User{}                                                            #=> %User{age: 27, email: nil, name: "John"}
+  # Since doing it in reverse will generate a syntax error.
+    defmodule User do
+      defstruct [name: "John", age: 27, :email]
+    end
+      #=> ** (SyntaxError) iex:107: syntax error before: email
+  # You can also require that certain keys be specified when creating the structure.
+    defmodule Car do
+      @enforce_keys [:make]
+      defstruct [:model, :make]
+    end
+    %Car{}
+      #=> ** (ArgumentError) the following keys must also be given when building struct Car: [:make]
+    expanding struct: Car.__struct__/1

--- a/chapter15
+++ b/chapter15
@@ -1,0 +1,49 @@
+Structs
+  # structures are extensions built on top of maps that provide compile-time checks and default values.
+
+Defining structs
+  # The defstruct construct is used.
+    defmodule User do
+      defstruct name: "John", age: 27
+    end
+  # The keyword list used with defstruct defines which fields the structure will have along with their default values.
+  # Structures take the name of the module in which they are defined. In the previous example, we defined a structure called User.
+  # You can create structures using a syntax similar to that used to create maps
+    %User{}                                                       #=> %User{age: 27, name: "John"}
+    %User{name: "Jane"}                                           #=> %User{age: 27, name: "Jane"}
+  # only the fields defined within the structure may exist.
+    %User{oops: :field}                                           #=> ** (KeyError) key :oops not found in: %User{age: 27, name: "John"}
+
+Accessing and updating structs
+  # In the structures as in the maps and lists the data can be accessed, it can also be updated.
+    john = %User{}                                                #=> %User{age: 27, name: "John"}
+    john.name                                                     #=> "John"
+    jane = %{john | name: "Jane"}                                 #=> %User{age: 27, name: "Jane"}
+    %{jane | oops: :field}                                        #=> ** (KeyError) key :oops not found in: %User{age: 27, name: "Jane"}
+  # Structures can also be used in pattern matching, both to match the value of specific keys and to ensure that the matching value is a structure of the same type as the matching value.
+    %User{name: name} = john                                      #=> %User{age: 27, name: "John"}
+    name                                                          #=> "John"
+    %User{} = %{}                                                 #=> ** (MatchError) no match of right hand side value: %{}
+
+Structs are bare maps underneath
+  # pattern matching works because below the structures are bare maps with a fixed set of fields.
+   # structures store a "special" field called __struct__ which contains the name of the structure.
+    is_map(john)                                                  #=> true
+    john.__struct__                                               #=> User
+  # structures are like naked maps because none of the protocols implemented for maps are available for structures.
+    john = %User{}                                                #=> %User{age: 27, name: "John"}
+      #=> ** (UndefinedFunctionError) function User.fetch/2 is undefined (User does not implement the Access behaviour)
+             User.fetch(%User{age: 27, name: "John"}, :name)
+    Enum.each john, fn({field, value}) -> IO.puts(value) end
+      #=> ** (Protocol.UndefinedError) protocol Enumerable not implemented for %User{age: 27, name: "John"}
+  # However, since the structures are only maps, they work with the Map module functions.
+    jane = Map.put(%User{}, :name, "Jane")                        #=> %User{age: 27, name: "Jane"}
+    Map.merge(jane, %User{name: "John"})                          #=> %User{age: 27, name: "John"}
+    Map.keys(jane)                                                #=> [:__struct__, :age, :name]
+
+Default values and required keys
+  # If a default value is not specified when defining the structure, it will take the value nil.
+    defmodule Product do
+      defstruct [:name]
+    end
+    %Product{}                                                    #=> %Product{name: nil}


### PR DESCRIPTION
In this section we have worked on chapters 13, 14, 15 where we talk about three alternatives that elixir has for reuse as aliases, import, require.

It also talks about the attributes of modules in Elixir that have three purposes, the first serve to annotate the module, often with information to be used by the user or the VM, the second function as constants, and the third function as a temporary storage module to be used during compilation.

in addition to structures, these are extensions built on maps that provide compile-time checks and default values.

which cannot use the map functions as they are like naked maps.